### PR TITLE
CP-18646: Make packer-build-xenserver support other-config for vm pac…

### DIFF
--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -22,9 +22,10 @@ type config struct {
 	common.PackerConfig   `mapstructure:",squash"`
 	xscommon.CommonConfig `mapstructure:",squash"`
 
-	VMMemory      uint   `mapstructure:"vm_memory"`
-	DiskSize      uint   `mapstructure:"disk_size"`
-	CloneTemplate string `mapstructure:"clone_template"`
+	VMMemory      uint              `mapstructure:"vm_memory"`
+	DiskSize      uint              `mapstructure:"disk_size"`
+	CloneTemplate string            `mapstructure:"clone_template"`
+	VMOtherConfig map[string]string `mapstructure:"vm_other_config"`
 
 	ISOChecksum     string   `mapstructure:"iso_checksum"`
 	ISOChecksumType string   `mapstructure:"iso_checksum_type"`

--- a/builder/xenserver/iso/step_create_instance.go
+++ b/builder/xenserver/iso/step_create_instance.go
@@ -56,16 +56,24 @@ func (self *stepCreateInstance) Run(state multistep.StateBag) multistep.StepActi
 		return multistep.ActionHalt
 	}
 
-	instance.SetPlatform(config.PlatformArgs)
+	err = instance.SetPlatform(config.PlatformArgs)
 	if err != nil {
 		ui.Error(fmt.Sprintf("Error setting VM platform: %s", err.Error()))
 		return multistep.ActionHalt
 	}
 
-	instance.SetDescription(config.VMDescription)
+	err = instance.SetDescription(config.VMDescription)
 	if err != nil {
 		ui.Error(fmt.Sprintf("Error setting VM description: %s", err.Error()))
 		return multistep.ActionHalt
+	}
+
+	if len(config.VMOtherConfig) != 0 {
+		err = instance.SetOtherConfig(config.VMOtherConfig)
+		if err != nil {
+			ui.Error(fmt.Sprintf("Error setting VM other-config: %s", err.Error()))
+			return multistep.ActionHalt
+		}
 	}
 
 	// Create VDI for the instance


### PR DESCRIPTION
When doing packer vpx-conversion, we need a map "conversionvm":"true" in the "other-config" property.
This commit added this feature.

Signed-off-by: kunm <kun.ma@citrix.com>