### PR TITLE
CP-18791: Make appliance-specs building stable

### DIFF
--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -309,6 +309,9 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 			VdiUuidKey: "iso_vdi_uuid",
 		},
 		&xscommon.StepDetachVdi{
+			VdiUuidKey: "isoname_vdi_uuid",
+		},
+		&xscommon.StepDetachVdi{
 			VdiUuidKey: "tools_vdi_uuid",
 		},
 		&xscommon.StepDetachVdi{


### PR DESCRIPTION
We should detach the isoname_vid after shutdown vm.
Otherwise the iso will keep the first dev number, next time vm was imported to other host and start, /dev/xvda could not be found.

Signed-off-by: Kun Ma <kun.ma@citrix.com>