### PR TITLE
Added step to configure number of disk drives

### DIFF
--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -50,10 +50,11 @@ type CommonConfig struct {
 	RawSSHWaitTimeout string `mapstructure:"ssh_wait_timeout"`
 	SSHWaitTimeout    time.Duration
 
-	OutputDir string `mapstructure:"output_directory"`
-	Format    string `mapstructure:"format"`
-	KeepVM    string `mapstructure:"keep_vm"`
-	IPGetter  string `mapstructure:"ip_getter"`
+	OutputDir  string `mapstructure:"output_directory"`
+	Format     string `mapstructure:"format"`
+	DiskDrives uint   `mapstructure:"disk_drives"`
+	KeepVM     string `mapstructure:"keep_vm"`
+	IPGetter   string `mapstructure:"ip_getter"`
 }
 
 func (c *CommonConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig) []error {

--- a/builder/xenserver/common/step_configure_disk_drives.go
+++ b/builder/xenserver/common/step_configure_disk_drives.go
@@ -1,0 +1,103 @@
+package common
+
+import (
+	"fmt"
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+	"github.com/nilshell/xmlrpc"
+	xsclient "github.com/xenserver/go-xenserver-client"
+	"strings"
+)
+
+type StepConfigureDiskDrives struct{}
+
+func (self *StepConfigureDiskDrives) Run(state multistep.StateBag) multistep.StepAction {
+	ui := state.Get("ui").(packer.Ui)
+	config := state.Get("commonconfig").(CommonConfig)
+	client := state.Get("client").(xsclient.XenAPIClient)
+	ui.Say("Step: Configure disk drives")
+
+	uuid := state.Get("instance_uuid").(string)
+	instance, err := client.GetVMByUuid(uuid)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Unable to get VM from UUID '%s': %s", uuid, err.Error()))
+		return multistep.ActionHalt
+	}
+
+	vbds, err := instance.GetVBDs()
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error getting VBDs: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
+	var current_number_of_disk_drives uint = 0
+	for _, vbd := range vbds {
+		vbd_rec, err := vbd.GetRecord()
+		if err != nil {
+			ui.Error(fmt.Sprintf("Error getting VBD record: %s", err.Error()))
+			return multistep.ActionHalt
+		}
+		if vbd_rec["type"].(string) == "CD" {
+			if current_number_of_disk_drives < config.DiskDrives {
+				ui.Say("Ejecting disk drive")
+				err = vbd.Eject()
+				if err != nil && !strings.Contains(err.Error(), "VBD_IS_EMPTY") {
+					ui.Error(fmt.Sprintf("Error ejecting VBD: %s", err.Error()))
+					return multistep.ActionHalt
+				}
+				current_number_of_disk_drives++
+			} else {
+				ui.Say("Destroying excess disk drive")
+				_ = vbd.Eject()
+				_ = vbd.Unplug()
+				err = vbd.Destroy()
+				if err != nil {
+					ui.Error(fmt.Sprintf("Error destroying VBD: %s", err.Error()))
+					return multistep.ActionHalt
+				}
+			}
+		}
+	}
+
+	if current_number_of_disk_drives < config.DiskDrives {
+		vbd_rec := make(xmlrpc.Struct)
+		vbd_rec["VM"] = instance.Ref
+		vbd_rec["VDI"] = "OpaqueRef:NULL"
+		vbd_rec["userdevice"] = "autodetect"
+		vbd_rec["empty"] = true
+		vbd_rec["other_config"] = make(xmlrpc.Struct)
+		vbd_rec["qos_algorithm_type"] = ""
+		vbd_rec["qos_algorithm_params"] = make(xmlrpc.Struct)
+		vbd_rec["mode"] = "RO"
+		vbd_rec["bootable"] = true
+		vbd_rec["unpluggable"] = false
+		vbd_rec["type"] = "CD"
+		for current_number_of_disk_drives < config.DiskDrives {
+			ui.Say("Creating disk drive")
+
+			result := xsclient.APIResult{}
+			err := client.APICall(&result, "VBD.create", vbd_rec)
+
+			if err != nil {
+				ui.Error("Error creating disk drive. Retrying...")
+				continue
+			}
+
+			vbd_ref := result.Value.(string)
+
+			result = xsclient.APIResult{}
+			err = client.APICall(&result, "VBD.get_uuid", vbd_ref)
+
+			if err != nil {
+				ui.Error("Error verifying disk drive. Retrying...")
+				continue
+			}
+
+			current_number_of_disk_drives++
+		}
+	}
+
+	return multistep.ActionContinue
+}
+
+func (self *StepConfigureDiskDrives) Cleanup(state multistep.StateBag) {}

--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -317,6 +317,7 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 		&xscommon.StepDetachVdi{
 			VdiUuidKey: "floppy_vdi_uuid",
 		},
+		new(xscommon.StepConfigureDiskDrives),
 		new(xscommon.StepExport),
 	}
 

--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -180,6 +180,7 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 		&xscommon.StepDetachVdi{
 			VdiUuidKey: "tools_vdi_uuid",
 		},
+		new(xscommon.StepConfigureDiskDrives),
 		new(xscommon.StepExport),
 	}
 

--- a/docs/builders/xenserver-iso.html.markdown
+++ b/docs/builders/xenserver-iso.html.markdown
@@ -100,6 +100,9 @@ each category, the available options are alphabetized and described.
   run `xe template-list`. Setting the correct value hints to XenServer how to
   optimize the virtual hardware to work best with that operating system.
 
+* `disk_drives` (integer) - How many DVD drives to keep on the exported VM.
+  Default is 0.
+
 * `disk_size` (integer) - The size, in megabytes, of the hard disk to create
   for the VM. By default, this is 40000 (about 40 GB).
 


### PR DESCRIPTION
I had a use case for this. Other people might as well.

Current behavior for ISO is to have 0 disk drives on the exported image
Exported XVAs to have the same number of disk drives as the original XVA

Now, the default behavior is to have 0 disk drives
The user can specify the number of disk drives in the exported image with `disk_drives` config