### PR TITLE
Added destroy vifs step

### DIFF
--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -50,6 +50,8 @@ type CommonConfig struct {
 	RawSSHWaitTimeout string `mapstructure:"ssh_wait_timeout"`
 	SSHWaitTimeout    time.Duration
 
+	DestroyVIFs bool `mapstructure:"destroy_vifs"`
+
 	OutputDir string `mapstructure:"output_directory"`
 	Format    string `mapstructure:"format"`
 	KeepVM    string `mapstructure:"keep_vm"`

--- a/builder/xenserver/common/step_destroy_vifs.go
+++ b/builder/xenserver/common/step_destroy_vifs.go
@@ -1,0 +1,47 @@
+package common
+
+import (
+	"fmt"
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+	xsclient "github.com/xenserver/go-xenserver-client"
+)
+
+type StepDestroyVIFs struct{}
+
+func (self *StepDestroyVIFs) Run(state multistep.StateBag) multistep.StepAction {
+	config := state.Get("commonconfig").(CommonConfig)
+	if !config.DestroyVIFs {
+		return multistep.ActionContinue
+	}
+
+	ui := state.Get("ui").(packer.Ui)
+	client := state.Get("client").(xsclient.XenAPIClient)
+
+	ui.Say("Step: Destroy VIFs")
+
+	uuid := state.Get("instance_uuid").(string)
+	instance, err := client.GetVMByUuid(uuid)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Unable to get VM from UUID '%s': %s", uuid, err.Error()))
+		return multistep.ActionHalt
+	}
+
+	vifs, err := instance.GetVIFs()
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error getting VIFs: %s", err.Error()))
+		return multistep.ActionHalt
+	}
+
+	for _, vif := range vifs {
+		err = vif.Destroy()
+		if err != nil {
+			ui.Error(fmt.Sprintf("Error destroying VIF: %s", err.Error()))
+			return multistep.ActionHalt
+		}
+	}
+
+	return multistep.ActionContinue
+}
+
+func (self *StepDestroyVIFs) Cleanup(state multistep.StateBag) {}

--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -317,6 +317,7 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 		&xscommon.StepDetachVdi{
 			VdiUuidKey: "floppy_vdi_uuid",
 		},
+		new(xscommon.StepDestroyVIFs),
 		new(xscommon.StepExport),
 	}
 

--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -180,6 +180,7 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 		&xscommon.StepDetachVdi{
 			VdiUuidKey: "tools_vdi_uuid",
 		},
+		new(xscommon.StepDestroyVIFs),
 		new(xscommon.StepExport),
 	}
 

--- a/docs/builders/xenserver-iso.html.markdown
+++ b/docs/builders/xenserver-iso.html.markdown
@@ -100,6 +100,10 @@ each category, the available options are alphabetized and described.
   run `xe template-list`. Setting the correct value hints to XenServer how to
   optimize the virtual hardware to work best with that operating system.
 
+* `destroy_vifs` (boolean) - Whether to destroy VIFs on the VM prior to
+  exporting. Removing them may make the image more generic and reusable.
+  Default is `false`.
+
 * `disk_size` (integer) - The size, in megabytes, of the hard disk to create
   for the VM. By default, this is 40000 (about 40 GB).
 


### PR DESCRIPTION
* `destroy_vifs` (boolean) - Whether to destroy VIFs on the VM prior to
  exporting. Removing them may make the image more generic and reusable.
  Default is `false`.