### PR TITLE
Fix WinRM wrong host and port. Fix require ssh_username when using WinRM

### DIFF
--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -39,6 +39,8 @@ type CommonConfig struct {
 	HTTPPortMin uint   `mapstructure:"http_port_min"`
 	HTTPPortMax uint   `mapstructure:"http_port_max"`
 
+	Communicator string `mapstructure:"communicator"`
+
 	//	SSHHostPortMin    uint   `mapstructure:"ssh_host_port_min"`
 	//	SSHHostPortMax    uint   `mapstructure:"ssh_host_port_max"`
 	SSHKeyPath  string `mapstructure:"ssh_key_path"`
@@ -174,7 +176,7 @@ func (c *CommonConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig
 		}
 	*/
 
-	if c.SSHUser == "" {
+	if c.SSHUser == "" && c.Communicator != "winrm" {
 		errs = append(errs, errors.New("An ssh_username must be specified."))
 	}
 

--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -52,6 +52,7 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 
 	errs = packer.MultiErrorAppend(
 		errs, self.config.CommonConfig.Prepare(&self.config.ctx, &self.config.PackerConfig)...)
+	errs = packer.MultiErrorAppend(errs, self.config.SSHConfig.Prepare(&self.config.ctx)...)
 
 	// Set default values
 

--- a/vendor/github.com/mitchellh/packer/helper/communicator/step_connect_winrm.go
+++ b/vendor/github.com/mitchellh/packer/helper/communicator/step_connect_winrm.go
@@ -91,19 +91,22 @@ func (s *StepConnectWinRM) waitForWinRM(state multistep.StateBag, cancel <-chan 
 		case <-time.After(5 * time.Second):
 		}
 
-		host, err := s.Host(state)
-		if err != nil {
-			log.Printf("[DEBUG] Error getting WinRM host: %s", err)
-			continue
+		var host string
+		if hostRaw, ok := state.GetOk("instance_ssh_address"); ok {
+			host = hostRaw.(string)
+		} else {
+			log.Println("[INFO] Error getting WinRM host. Exiting loop.")
+			return nil, errors.New("Error getting WinRM host")
 		}
+
 		port := s.Config.WinRMPort
-		if s.WinRMPort != nil {
-			port, err = s.WinRMPort(state)
-			if err != nil {
-				log.Printf("[DEBUG] Error getting WinRM port: %s", err)
-				continue
-			}
-		}
+		// if s.WinRMPort != nil {
+		// 	port, err = s.WinRMPort(state)
+		// 	if err != nil {
+		// 		log.Printf("[DEBUG] Error getting WinRM port: %s", err)
+		// 		continue
+		// 	}
+		// }
 
 		user := s.Config.WinRMUser
 		password := s.Config.WinRMPassword
@@ -122,6 +125,7 @@ func (s *StepConnectWinRM) waitForWinRM(state multistep.StateBag, cancel <-chan 
 			}
 		}
 
+		var err error
 		log.Println("[INFO] Attempting WinRM connection...")
 		comm, err = winrm.New(&winrm.Config{
 			Host:               host,


### PR DESCRIPTION
Current code tries to run WinRM against the wrong host and wrong port.
`ssh_username` should not be required when using WinRM

This PR probably won't get accepted due to the changes I've made in `step_connect_winrm.go`
But it is what works for me.

Please consider fixing these issues if you will not merge this PR.