### PR TITLE
CP-19741: Change network config for VPXs (WLB, XCM and DLVM) from "Bo…

### DIFF
--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -18,11 +18,12 @@ type CommonConfig struct {
 	Password string `mapstructure:"remote_password"`
 	HostIp   string `mapstructure:"remote_host"`
 
-	VMName        string   `mapstructure:"vm_name"`
-	VMDescription string   `mapstructure:"vm_description"`
-	SrName        string   `mapstructure:"sr_name"`
-	FloppyFiles   []string `mapstructure:"floppy_files"`
-	NetworkNames  []string `mapstructure:"network_names"`
+	VMName             string   `mapstructure:"vm_name"`
+	VMDescription      string   `mapstructure:"vm_description"`
+	SrName             string   `mapstructure:"sr_name"`
+	FloppyFiles        []string `mapstructure:"floppy_files"`
+	NetworkNames       []string `mapstructure:"network_names"`
+	ExportNetworkNames []string `mapstructure:"export_network_names"`
 
 	HostPortMin uint `mapstructure:"host_port_min"`
 	HostPortMax uint `mapstructure:"host_port_max"`

--- a/builder/xenserver/common/step_export.go
+++ b/builder/xenserver/common/step_export.go
@@ -93,6 +93,47 @@ func (StepExport) Run(state multistep.StateBag) multistep.StepAction {
 		return multistep.ActionHalt
 	}
 
+	if len(config.ExportNetworkNames) > 0 {
+		vifs, err := instance.GetVIFs()
+		if err != nil {
+			ui.Error(fmt.Sprintf("Error occured getting VIFs: %s", err.Error()))
+			return multistep.ActionHalt
+		}
+
+		for _, vif := range vifs {
+			err := vif.Destroy()
+			if err != nil {
+				ui.Error(fmt.Sprintf("Destroy vif fail: '%s': %s", vif.Ref, err.Error()))
+				return multistep.ActionHalt
+			}
+		}
+		for i, networkNameLabel := range config.ExportNetworkNames {
+			networks, err := client.GetNetworkByNameLabel(networkNameLabel)
+
+			if err != nil {
+				ui.Error(fmt.Sprintf("Error occured getting Network by name-label: %s", err.Error()))
+				return multistep.ActionHalt
+			}
+
+			switch {
+			case len(networks) == 0:
+				ui.Error(fmt.Sprintf("Couldn't find a network with the specified name-label '%s'. Aborting.", networkNameLabel))
+				return multistep.ActionHalt
+			case len(networks) > 1:
+				ui.Error(fmt.Sprintf("Found more than one network with the name '%s'. The name must be unique. Aborting.", networkNameLabel))
+				return multistep.ActionHalt
+			}
+
+			//we need the VIF index string
+			vifIndexString := fmt.Sprintf("%d", i)
+			_, err = instance.ConnectNetwork(networks[0], vifIndexString)
+
+			if err != nil {
+				ui.Say(err.Error())
+			}
+		}
+	}
+
 	ui.Say("Step: export artifact")
 
 	compress_option_xe := "compress=false"


### PR DESCRIPTION
To prevent the impact of packer server network config different from deploy environment, we should provide a method for changing VIF config before export VM.

Signed-off-by: Kun Ma <kun.ma@citrix.com>