### PR TITLE
Fix SSH handling in pool environment.

### DIFF
--- a/builder/xenserver/common/ssh.go
+++ b/builder/xenserver/common/ssh.go
@@ -87,6 +87,7 @@ func doExecuteSSHCmd(cmd, target string, config *gossh.ClientConfig) (stdout str
 
 func ExecuteHostSSHCmd(state multistep.StateBag, cmd string) (stdout string, err error) {
 	config := state.Get("commonconfig").(CommonConfig)
+	sshAddress, _ := SSHAddress(state)
 	// Setup connection config
 	sshConfig := &gossh.ClientConfig{
 		User: config.Username,
@@ -94,7 +95,7 @@ func ExecuteHostSSHCmd(state multistep.StateBag, cmd string) (stdout string, err
 			gossh.Password(config.Password),
 		},
 	}
-	return doExecuteSSHCmd(cmd, config.HostIp+":22", sshConfig)
+	return doExecuteSSHCmd(cmd, sshAddress, sshConfig)
 }
 
 func ExecuteGuestSSHCmd(state multistep.StateBag, cmd string) (stdout string, err error) {

--- a/builder/xenserver/common/step_forward_port_over_ssh.go
+++ b/builder/xenserver/common/step_forward_port_over_ssh.go
@@ -32,11 +32,12 @@ func (self *StepForwardPortOverSSH) Run(state multistep.StateBag) multistep.Step
 
 	ui.Say(fmt.Sprintf("Creating a local port forward over SSH on local port %d", sshHostPort))
 
+	hostAddress, _ := state.Get("ssh_address").(string)
 	remotePort, _ := self.RemotePort(state)
 	remoteDest, _ := self.RemoteDest(state)
 
-	go ssh_port_forward(l, remotePort, remoteDest, config.HostIp, config.Username, config.Password)
-	ui.Say(fmt.Sprintf("Port forward setup. %d ---> %s:%d on %s", sshHostPort, remoteDest, remotePort, config.HostIp))
+	go ssh_port_forward(l, remotePort, remoteDest, hostAddress, config.Username, config.Password)
+	ui.Say(fmt.Sprintf("Port forward setup. %d ---> %s:%d on %s", sshHostPort, remoteDest, remotePort, hostAddress))
 
 	// Provide the local port to future steps.
 	state.Put(self.ResultKey, sshHostPort)

--- a/builder/xenserver/common/step_set_vm_host_ssh_address.go
+++ b/builder/xenserver/common/step_set_vm_host_ssh_address.go
@@ -1,0 +1,42 @@
+package common
+
+import (
+	"fmt"
+	"github.com/mitchellh/multistep"
+	"github.com/mitchellh/packer/packer"
+	xsclient "github.com/xenserver/go-xenserver-client"
+)
+
+type StepSetVmHostSshAddress struct{}
+
+func (self *StepSetVmHostSshAddress) Run(state multistep.StateBag) multistep.StepAction {
+
+	client := state.Get("client").(xsclient.XenAPIClient)
+	ui := state.Get("ui").(packer.Ui)
+
+	ui.Say("Step: Set SSH address to VM host IP")
+
+	uuid := state.Get("instance_uuid").(string)
+	instance, err := client.GetVMByUuid(uuid)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Unable to get VM from UUID '%s': %s", uuid, err.Error()))
+		return multistep.ActionHalt
+	}
+
+	host, err := instance.GetResidentOn()
+	if err != nil {
+		ui.Error(fmt.Sprintf("Unable to get VM Host for VM '%s': %s", uuid, err.Error()))
+	}
+
+	address, err := host.GetAddress()
+	if err != nil {
+		ui.Error(fmt.Sprintf("Unable to get address from VM Host: %s", err.Error()))
+	}
+
+	state.Put("ssh_address", address)
+	ui.Say(fmt.Sprintf("Set host SSH address to '%s'.", address))
+
+	return multistep.ActionContinue
+}
+
+func (self *StepSetVmHostSshAddress) Cleanup(state multistep.StateBag) {}

--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -274,6 +274,7 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 			VdiType:    xsclient.CD,
 		},
 		new(xscommon.StepStartVmPaused),
+		new(xscommon.StepSetVmHostSshAddress),
 		new(xscommon.StepGetVNCPort),
 		&xscommon.StepForwardPortOverSSH{
 			RemotePort:  xscommon.InstanceVNCPort,

--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -143,6 +143,7 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 			VdiType:    xsclient.CD,
 		},
 		new(xscommon.StepStartVmPaused),
+		new(xscommon.StepSetVmHostSshAddress),
 		new(xscommon.StepGetVNCPort),
 		&xscommon.StepForwardPortOverSSH{
 			RemotePort:  xscommon.InstanceVNCPort,


### PR DESCRIPTION
This adds a new build step executed after StepStartVmPaused. This sets
the "ssh_address" state variable to the IP of the host the VM was started on.
This enables SSH commands to work correctly in a pool environment.

This also modifies SSH calls to use this address rather than config.HostIp

Fixes #47