### PR TITLE
#85 Support communicating with Xen API over TLS

### DIFF
--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -10,6 +10,8 @@ import (
 	"github.com/mitchellh/packer/common"
 	commonssh "github.com/mitchellh/packer/common/ssh"
 	"github.com/mitchellh/packer/template/interpolate"
+
+	xmlrpc "github.com/nilshell/xmlrpc"
 	xsclient "github.com/xenserver/go-xenserver-client"
 )
 
@@ -17,6 +19,7 @@ type CommonConfig struct {
 	Username string `mapstructure:"remote_username"`
 	Password string `mapstructure:"remote_password"`
 	HostIp   string `mapstructure:"remote_host"`
+	ApiUrl   string `mapstructure:"remote_url"`
 
 	VMName             string   `mapstructure:"vm_name"`
 	VMDescription      string   `mapstructure:"vm_description"`
@@ -147,6 +150,10 @@ func (c *CommonConfig) Prepare(ctx *interpolate.Context, pc *common.PackerConfig
 		errs = append(errs, errors.New("remote_host must be specified."))
 	}
 
+	if c.ApiUrl == "" {
+		c.ApiUrl = "http://" + c.HostIp
+	}
+
 	if c.HostPortMin > c.HostPortMax {
 		errs = append(errs, errors.New("the host min port must be less than the max"))
 	}
@@ -244,4 +251,22 @@ func (config CommonConfig) GetSR(client xsclient.XenAPIClient) (*xsclient.SR, er
 
 		return srs[0], nil
 	}
+}
+
+func (config CommonConfig) GetXenAPIClient() (*xsclient.XenAPIClient, error) {
+	rpc, err := xmlrpc.NewClient(config.ApiUrl, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	client := xsclient.XenAPIClient{
+		Username: config.Username,
+		Password: config.Password,
+		Host:     config.HostIp,
+		Url:      config.ApiUrl,
+		RPC:      rpc,
+	}
+
+	return &client, nil
 }

--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -178,9 +178,13 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 
 func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packer.Artifact, error) {
 	//Setup XAPI client
-	client := xsclient.NewXenAPIClient(self.config.HostIp, self.config.Username, self.config.Password)
+	_client, err := self.config.CommonConfig.GetXenAPIClient()
+	if err != nil {
+		return nil, err.(error)
+	}
+	client := *_client
 
-	err := client.Login()
+	err = client.Login()
 	if err != nil {
 		return nil, err.(error)
 	}

--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -86,9 +86,13 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 
 func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (packer.Artifact, error) {
 	//Setup XAPI client
-	client := xsclient.NewXenAPIClient(self.config.HostIp, self.config.Username, self.config.Password)
+	_client, err := self.config.CommonConfig.GetXenAPIClient()
+	if err != nil {
+		return nil, err.(error)
+	}
+	client := *_client
 
-	err := client.Login()
+	err = client.Login()
 	if err != nil {
 		return nil, err.(error)
 	}


### PR DESCRIPTION
This commit adds two new config flags:

- `remote_url`: url to use when connecting to the Xen API (defaults to `http://{remote_host}`)
- `remote_url_tls_skip_verify`: disables certificate verification for `remote_url`

I've added the second option because we are using self-signed certs on some of our our Xen servers (there are plans to fix this soon), but it could also be useful for others during testing/evaluation.