### PR TITLE
Add ssh_no_proxy parameter (via @gaserre to address issue #84)

### DIFF
--- a/builder/xenserver/common/common_config.go
+++ b/builder/xenserver/common/common_config.go
@@ -42,6 +42,7 @@ type CommonConfig struct {
 
 	//	SSHHostPortMin    uint   `mapstructure:"ssh_host_port_min"`
 	//	SSHHostPortMax    uint   `mapstructure:"ssh_host_port_max"`
+	SSHNoProxy  bool   `mapstructure:"ssh_no_proxy"`
 	SSHKeyPath  string `mapstructure:"ssh_key_path"`
 	SSHPassword string `mapstructure:"ssh_password"`
 	SSHPort     uint   `mapstructure:"ssh_port"`

--- a/builder/xenserver/common/ssh.go
+++ b/builder/xenserver/common/ssh.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"github.com/mitchellh/multistep"
 	commonssh "github.com/mitchellh/packer/common/ssh"
@@ -19,6 +20,12 @@ func SSHAddress(state multistep.StateBag) (string, error) {
 	return fmt.Sprintf("%s:%d", sshIP, sshHostPort), nil
 }
 
+func SSHInstanceAddress(state multistep.StateBag) (string, error) {
+	sshIP := state.Get("instance_ssh_address").(string)
+	sshPort := 22
+	return fmt.Sprintf("%s:%d", sshIP, sshPort), nil
+}
+
 func SSHLocalAddress(state multistep.StateBag) (string, error) {
 	sshLocalPort, ok := state.Get("local_ssh_port").(uint)
 	if !ok {
@@ -30,11 +37,26 @@ func SSHLocalAddress(state multistep.StateBag) (string, error) {
 
 func SSHPort(state multistep.StateBag) (int, error) {
 	sshHostPort := state.Get("local_ssh_port").(uint)
+	if sshHostPort == 0 {
+		sshHostPort = state.Get("commonconfig").(CommonConfig).SSHPort
+  }
 	return int(sshHostPort), nil
 }
 
 func CommHost(state multistep.StateBag) (string, error) {
-	return "127.0.0.1", nil
+	var sshIP string
+	config := state.Get("commonconfig").(CommonConfig)
+	if config.SSHNoProxy {
+		sshIP = state.Get("instance_ssh_address").(string)
+	} else {
+		if state.Get("local_ssh_port").(uint) > 0 {
+			sshIP = "127.0.0.1"
+		} else {
+			return "", errors.New("CommHost: local_ssh_port not set")
+		}
+	}
+	log.Printf("[DEBUG] CommHost: sshIP: %s", sshIP)
+	return sshIP, nil
 }
 
 func SSHConfigFunc(config SSHConfig) func(multistep.StateBag) (*gossh.ClientConfig, error) {
@@ -99,17 +121,24 @@ func ExecuteHostSSHCmd(state multistep.StateBag, cmd string) (stdout string, err
 }
 
 func ExecuteGuestSSHCmd(state multistep.StateBag, cmd string) (stdout string, err error) {
-	config := state.Get("commonconfig").(CommonConfig)
-	localAddress, err := SSHLocalAddress(state)
-	if err != nil {
-		return
+  config := state.Get("commonconfig").(CommonConfig)
+	var address string
+	var address_err error
+	if config.SSHNoProxy {
+		address, address_err = SSHInstanceAddress(state)
+	} else {
+		address, err = SSHLocalAddress(state)
+  	}
+	if address_err != nil {
+		return "", address_err
 	}
-	sshConfig, err := SSHConfigFunc(config.SSHConfig)(state)
-	if err != nil {
-		return
-	}
+	sshConfig, ssh_err := SSHConfigFunc(config.SSHConfig)(state)
+	if ssh_err != nil {
+  	return
+  }
 
-	return doExecuteSSHCmd(cmd, localAddress, sshConfig)
+	log.Printf("[DEBUG] doExecuteSSHCmd: %s, %s", cmd, address)
+	return doExecuteSSHCmd(cmd, address, sshConfig)
 }
 
 func forward(local_conn net.Conn, config *gossh.ClientConfig, server, remote_dest string, remote_port uint) error {

--- a/builder/xenserver/common/step_forward_port_over_ssh.go
+++ b/builder/xenserver/common/step_forward_port_over_ssh.go
@@ -7,6 +7,8 @@ import (
 )
 
 type StepForwardPortOverSSH struct {
+	// If NoProxy, don't do proxying (forwarding)
+	NoProxy    bool
 	RemotePort func(state multistep.StateBag) (uint, error)
 	RemoteDest func(state multistep.StateBag) (string, error)
 
@@ -20,6 +22,11 @@ func (self *StepForwardPortOverSSH) Run(state multistep.StateBag) multistep.Step
 
 	config := state.Get("commonconfig").(CommonConfig)
 	ui := state.Get("ui").(packer.Ui)
+	if self.NoProxy {
+		ui.Say(fmt.Sprintf("Not using SSH port forwarding"))
+		state.Put(self.ResultKey, uint(0))
+		return multistep.ActionContinue
+	}
 
 	// Find a free local port:
 

--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -277,6 +277,7 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 		new(xscommon.StepSetVmHostSshAddress),
 		new(xscommon.StepGetVNCPort),
 		&xscommon.StepForwardPortOverSSH{
+			NoProxy:     false,
 			RemotePort:  xscommon.InstanceVNCPort,
 			RemoteDest:  xscommon.InstanceVNCIP,
 			HostPortMin: self.config.HostPortMin,
@@ -292,6 +293,7 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 			Timeout: self.config.InstallTimeout, // @todo change this
 		},
 		&xscommon.StepForwardPortOverSSH{
+			NoProxy:     self.config.SSHNoProxy,
 			RemotePort:  xscommon.InstanceSSHPort,
 			RemoteDest:  xscommon.InstanceSSHIP,
 			HostPortMin: self.config.HostPortMin,

--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -146,6 +146,7 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 		new(xscommon.StepSetVmHostSshAddress),
 		new(xscommon.StepGetVNCPort),
 		&xscommon.StepForwardPortOverSSH{
+			NoProxy:     false,
 			RemotePort:  xscommon.InstanceVNCPort,
 			RemoteDest:  xscommon.InstanceVNCIP,
 			HostPortMin: self.config.HostPortMin,
@@ -161,6 +162,7 @@ func (self *Builder) Run(ui packer.Ui, hook packer.Hook, cache packer.Cache) (pa
 			Timeout: 300 * time.Minute, /*self.config.InstallTimeout*/ // @todo change this
 		},
 		&xscommon.StepForwardPortOverSSH{
+			NoProxy:     self.config.SSHNoProxy,
 			RemotePort:  xscommon.InstanceSSHPort,
 			RemoteDest:  xscommon.InstanceSSHIP,
 			HostPortMin: self.config.HostPortMin,


### PR DESCRIPTION
Via @gaserre:

If ssh_no_proxy is specified, do not use a proxy (port forwarding) 
when executing the provision and shutdown steps.
The reason to avoid proxying is that the current implementation does not
handle ssh disconnects properly.
The VNC boot command still uses the proxy.