### PR TITLE
Add options to configure the number of VCPUs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ A brief explanation of what the config parameters mean:
  * `remote_password` - the password for the XenServer host being used.
  * `remote_host` - the IP for the XenServer host being used.
  * `vm_name` - the name that should be given to the created VM.
+ * `vcpus_max` - the maximum number of VCPUs for the VM.
+ * `vcpus_atstartup` - the number of startup VCPUs for the VM.
  * `vm_memory` - the static memory configuration for the VM, in MB.
  * `disk_size` - the size of the disk the VM should be created with, in MB.
  * `iso_name` - the name of the ISO visible on a ISO SR connected to the XenServer host.

--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -22,12 +22,12 @@ type config struct {
 	common.PackerConfig   `mapstructure:",squash"`
 	xscommon.CommonConfig `mapstructure:",squash"`
 
-	VCPUsMax        uint              `mapstructure:"vcpus_max"`
-	VCPUsAtStartup  uint              `mapstructure:"vcpus_atstartup"`
-	VMMemory        uint              `mapstructure:"vm_memory"`
-	DiskSize        uint              `mapstructure:"disk_size"`
-	CloneTemplate   string            `mapstructure:"clone_template"`
-	VMOtherConfig   map[string]string `mapstructure:"vm_other_config"`
+	VCPUsMax       uint              `mapstructure:"vcpus_max"`
+	VCPUsAtStartup uint              `mapstructure:"vcpus_atstartup"`
+	VMMemory       uint              `mapstructure:"vm_memory"`
+	DiskSize       uint              `mapstructure:"disk_size"`
+	CloneTemplate  string            `mapstructure:"clone_template"`
+	VMOtherConfig  map[string]string `mapstructure:"vm_other_config"`
 
 	ISOChecksum     string   `mapstructure:"iso_checksum"`
 	ISOChecksumType string   `mapstructure:"iso_checksum_type"`
@@ -88,7 +88,7 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 	}
 
 	if self.config.VCPUsAtStartup > self.config.VCPUsMax {
-	   	self.config.VCPUsAtStartup = self.config.VCPUsMax
+		self.config.VCPUsAtStartup = self.config.VCPUsMax
 	}
 
 	if self.config.VMMemory == 0 {

--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -107,7 +107,6 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 		pargs["apic"] = "true"
 		pargs["timeoffset"] = "0"
 		pargs["acpi"] = "1"
-		pargs["cores-per-socket"] = "1"
 		self.config.PlatformArgs = pargs
 	}
 

--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -22,10 +22,12 @@ type config struct {
 	common.PackerConfig   `mapstructure:",squash"`
 	xscommon.CommonConfig `mapstructure:",squash"`
 
-	VMMemory      uint              `mapstructure:"vm_memory"`
-	DiskSize      uint              `mapstructure:"disk_size"`
-	CloneTemplate string            `mapstructure:"clone_template"`
-	VMOtherConfig map[string]string `mapstructure:"vm_other_config"`
+	VCPUsMax        uint              `mapstructure:"vcpus_max"`
+	VCPUsAtStartup  uint              `mapstructure:"vcpus_atstartup"`
+	VMMemory        uint              `mapstructure:"vm_memory"`
+	DiskSize        uint              `mapstructure:"disk_size"`
+	CloneTemplate   string            `mapstructure:"clone_template"`
+	VMOtherConfig   map[string]string `mapstructure:"vm_other_config"`
 
 	ISOChecksum     string   `mapstructure:"iso_checksum"`
 	ISOChecksumType string   `mapstructure:"iso_checksum_type"`
@@ -77,6 +79,18 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 		self.config.DiskSize = 40000
 	}
 
+	if self.config.VCPUsMax == 0 {
+		self.config.VCPUsMax = 1
+	}
+
+	if self.config.VCPUsAtStartup == 0 {
+		self.config.VCPUsAtStartup = 1
+	}
+
+	if self.config.VCPUsAtStartup > self.config.VCPUsMax {
+	   	self.config.VCPUsAtStartup = self.config.VCPUsMax
+	}
+
 	if self.config.VMMemory == 0 {
 		self.config.VMMemory = 1024
 	}
@@ -93,6 +107,7 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 		pargs["apic"] = "true"
 		pargs["timeoffset"] = "0"
 		pargs["acpi"] = "1"
+		pargs["cores-per-socket"] = "1"
 		self.config.PlatformArgs = pargs
 	}
 

--- a/builder/xenserver/iso/step_create_instance.go
+++ b/builder/xenserver/iso/step_create_instance.go
@@ -50,6 +50,18 @@ func (self *stepCreateInstance) Run(state multistep.StateBag) multistep.StepActi
 		return multistep.ActionHalt
 	}
 
+	err = instance.SetVCPUsMax(config.VCPUsMax)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error setting VM VCPUs Max=%d: %s", config.VCPUsMax, err.Error()))
+		return multistep.ActionHalt
+	}
+
+	err = instance.SetVCPUsAtStartup(config.VCPUsAtStartup)
+	if err != nil {
+		ui.Error(fmt.Sprintf("Error setting VM VCPUs At Startup=%d: %s", config.VCPUsAtStartup, err.Error()))
+		return multistep.ActionHalt
+	}
+
 	err = instance.SetStaticMemoryRange(uint64(config.VMMemory*1024*1024), uint64(config.VMMemory*1024*1024))
 	if err != nil {
 		ui.Error(fmt.Sprintf("Error setting VM memory=%d: %s", config.VMMemory*1024*1024, err.Error()))

--- a/docs/builders/xenserver-iso.html.markdown
+++ b/docs/builders/xenserver-iso.html.markdown
@@ -167,7 +167,8 @@ each category, the available options are alphabetized and described.
     "pae": "true",
     "apic": "true",
     "timeoffset": "0",
-    "acpi": "1"
+    "acpi": "1",
+    "cores-per-socket": "1"
 }
 ```
 
@@ -210,6 +211,12 @@ each category, the available options are alphabetized and described.
 * `vm_name` (string) - This is the name of the new virtual
   machine, without the file extension. By default this is
   "packer-BUILDNAME-TIMESTAMP", where "BUILDNAME" is the name of the build.
+
+* `vcpus_max` (integer) - The maximum number of VCPUs for the VM.
+  By default this is 1.
+
+* `vcpus_atstartup` (integer) - The number of startup VCPUs for the VM.
+  By default this is 1.
 
 * `vm_memory` (integer) - The size, in megabytes, of the amount of memory to
   allocate for the VM. By default, this is 1024 (1 GB).


### PR DESCRIPTION
Add options to configure VCPUs-Max and VCPUs-AtStartup.
As topology is related with VCPUs settings, so I also add a default "cores-per-socket" in platform_args and mention it in document.