### PR TITLE
add fix for https://github.com/hashicorp/packer/issues/2156

### DIFF
--- a/builder/xenserver/common/step_type_boot_command.go
+++ b/builder/xenserver/common/step_type_boot_command.go
@@ -195,7 +195,9 @@ func vncSendString(c *vnc.ClientConn, original string) {
 		}
 
 		c.KeyEvent(keyCode, true)
+			time.Sleep(time.Second/10)
 		c.KeyEvent(keyCode, false)
+			time.Sleep(time.Second/10)
 
 		if keyShift {
 			c.KeyEvent(uint32(KeyLeftShift), false)


### PR DESCRIPTION
I noticed this same issue as reported at hashicorp/packer#2156 in the xenserver VNC. The commands are very unreliable and usually end up typing in garbled text. Adding this patch resolved it for me.