### PR TITLE
Set InterpolateContext

### DIFF
--- a/builder/xenserver/iso/builder.go
+++ b/builder/xenserver/iso/builder.go
@@ -53,7 +53,8 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 	var errs *packer.MultiError
 
 	err := hconfig.Decode(&self.config, &hconfig.DecodeOpts{
-		Interpolate: true,
+		Interpolate:        true,
+		InterpolateContext: &self.config.ctx,
 		InterpolateFilter: &interpolate.RenderFilter{
 			Exclude: []string{
 				"boot_command",

--- a/builder/xenserver/xva/builder.go
+++ b/builder/xenserver/xva/builder.go
@@ -38,7 +38,8 @@ func (self *Builder) Prepare(raws ...interface{}) (params []string, retErr error
 	var errs *packer.MultiError
 
 	err := hconfig.Decode(&self.config, &hconfig.DecodeOpts{
-		Interpolate: true,
+		Interpolate:        true,
+		InterpolateContext: &self.config.ctx,
 		InterpolateFilter: &interpolate.RenderFilter{
 			Exclude: []string{
 				"boot_command",


### PR DESCRIPTION
Setting the InterpolateContext fills out config.ctx in the builder to be passed into the steps that require it. For example, this allows user variables in the boot_command to be interpolated correctly.

Fixes #93.

This is how the core Hyper-V builder works: https://github.com/hashicorp/packer/blob/master/builder/hyperv/iso/builder.go#L108-L116